### PR TITLE
fix: update CI badge links and add npm and Homebrew release badges in README

### DIFF
--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -107,7 +107,7 @@ jobs:
       matrix:
         # Test all supported platforms natively
         # - ubuntu-latest: Linux x64
-        # - ubuntu-24.04-arm: Linux ARM64 (native ARM64 runner, available since 2025-01-16)
+        # - ubuntu-24.04-arm: Linux ARM64 (native ARM64 runner, available since 2025-01-16, public repositories only)
         # - macos-13: macOS Intel
         # - macos-latest: macOS Apple Silicon (M1/M2)
         # - windows-latest: Windows x64

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,10 +2,15 @@
 
 [![npm version](https://img.shields.io/npm/v/ai-chat-md-export.svg)](https://www.npmjs.com/package/ai-chat-md-export)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-orange.svg)](https://github.com/sugurutakahashi-1234/homebrew-tap)
-[![CI](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci.yml)
+[![CI](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci-push-main.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci-push-main.yml)
+[![npm Release](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-npm-release-auto.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-npm-release-auto.yml)
+[![Homebrew Release](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-homebrew-release.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-homebrew-release.yml)
 [![codecov](https://codecov.io/gh/sugurutakahashi-1234/ai-chat-md-export/graph/badge.svg?token=KPN7UZ7ATY)](https://codecov.io/gh/sugurutakahashi-1234/ai-chat-md-export)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm downloads](https://img.shields.io/npm/dm/ai-chat-md-export.svg)](https://www.npmjs.com/package/ai-chat-md-export)
+[![node](https://img.shields.io/node/v/ai-chat-md-export)](https://nodejs.org)
+[![npm bundle size](https://img.shields.io/bundlephobia/min/ai-chat-md-export)](https://bundlephobia.com/package/ai-chat-md-export)
+[![Types](https://img.shields.io/npm/types/ai-chat-md-export)](https://www.npmjs.com/package/ai-chat-md-export)
 
 ChatGPTとClaudeのチャット履歴をMarkdownに変換
 
@@ -52,17 +57,17 @@ ai-chat-md-export -i data.json --dry-run
 
 ## オプション
 
-| オプション | 短縮形 | 説明 | デフォルト |
-|--------|-------|-------------|---------|
-| `--input` | `-i` | 入力ファイル・ディレクトリ（必須） | - |
-| `--output` | `-o` | 出力ディレクトリ | カレントディレクトリ |
-| `--format` | `-f` | フォーマット: `chatgpt`、`claude`、`auto` | `auto` |
-| `--since` | - | 開始日（YYYY-MM-DD） | - |
-| `--until` | - | 終了日（YYYY-MM-DD） | - |
-| `--search` | - | 検索キーワード | - |
-| `--filename-encoding` | - | ファイル名エンコーディング: `standard`、`preserve` | `standard` |
-| `--quiet` | `-q` | 出力を抑制 | - |
-| `--dry-run` | - | プレビューモード | - |
+| オプション            | 短縮形 | 説明                                               | デフォルト           |
+| --------------------- | ------ | -------------------------------------------------- | -------------------- |
+| `--input`             | `-i`   | 入力ファイル・ディレクトリ（必須）                 | -                    |
+| `--output`            | `-o`   | 出力ディレクトリ                                   | カレントディレクトリ |
+| `--format`            | `-f`   | フォーマット: `chatgpt`、`claude`、`auto`          | `auto`               |
+| `--since`             | -      | 開始日（YYYY-MM-DD）                               | -                    |
+| `--until`             | -      | 終了日（YYYY-MM-DD）                               | -                    |
+| `--search`            | -      | 検索キーワード                                     | -                    |
+| `--filename-encoding` | -      | ファイル名エンコーディング: `standard`、`preserve` | `standard`           |
+| `--quiet`             | `-q`   | 出力を抑制                                         | -                    |
+| `--dry-run`           | -      | プレビューモード                                   | -                    |
 
 ## コントリビューション
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,15 @@
 
 [![npm version](https://img.shields.io/npm/v/ai-chat-md-export.svg)](https://www.npmjs.com/package/ai-chat-md-export)
 [![Homebrew](https://img.shields.io/badge/Homebrew-tap-orange.svg)](https://github.com/sugurutakahashi-1234/homebrew-tap)
-[![CI](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci.yml)
+[![CI](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci-push-main.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/ci-push-main.yml)
+[![npm Release](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-npm-release-auto.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-npm-release-auto.yml)
+[![Homebrew Release](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-homebrew-release.yml/badge.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/actions/workflows/cd-homebrew-release.yml)
 [![codecov](https://codecov.io/gh/sugurutakahashi-1234/ai-chat-md-export/graph/badge.svg?token=KPN7UZ7ATY)](https://codecov.io/gh/sugurutakahashi-1234/ai-chat-md-export)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![npm downloads](https://img.shields.io/npm/dm/ai-chat-md-export.svg)](https://www.npmjs.com/package/ai-chat-md-export)
+[![node](https://img.shields.io/node/v/ai-chat-md-export)](https://nodejs.org)
+[![npm bundle size](https://img.shields.io/bundlephobia/min/ai-chat-md-export)](https://bundlephobia.com/package/ai-chat-md-export)
+[![Types](https://img.shields.io/npm/types/ai-chat-md-export)](https://www.npmjs.com/package/ai-chat-md-export)
 
 Convert ChatGPT and Claude chat history to Markdown
 
@@ -54,17 +59,17 @@ ai-chat-md-export -i data.json --dry-run
 
 ## Options
 
-| Option | Short | Description | Default |
-|--------|-------|-------------|---------|
-| `--input` | `-i` | Input file or directory (required) | - |
-| `--output` | `-o` | Output directory | Current directory |
-| `--format` | `-f` | Format: `chatgpt`, `claude`, `auto` | `auto` |
-| `--since` | - | Filter from date (YYYY-MM-DD) | - |
-| `--until` | - | Filter until date (YYYY-MM-DD) | - |
-| `--search` | - | Search keyword | - |
-| `--filename-encoding` | - | Filename encoding: `standard`, `preserve` | `standard` |
-| `--quiet` | `-q` | Suppress output | - |
-| `--dry-run` | - | Preview mode | - |
+| Option                | Short | Description                               | Default           |
+| --------------------- | ----- | ----------------------------------------- | ----------------- |
+| `--input`             | `-i`  | Input file or directory (required)        | -                 |
+| `--output`            | `-o`  | Output directory                          | Current directory |
+| `--format`            | `-f`  | Format: `chatgpt`, `claude`, `auto`       | `auto`            |
+| `--since`             | -     | Filter from date (YYYY-MM-DD)             | -                 |
+| `--until`             | -     | Filter until date (YYYY-MM-DD)            | -                 |
+| `--search`            | -     | Search keyword                            | -                 |
+| `--filename-encoding` | -     | Filename encoding: `standard`, `preserve` | `standard`        |
+| `--quiet`             | `-q`  | Suppress output                           | -                 |
+| `--dry-run`           | -     | Preview mode                              | -                 |
 
 ## Contributing
 

--- a/scripts/test-binary.js
+++ b/scripts/test-binary.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { chmodSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 const projectRoot = join(import.meta.dir, "..");
@@ -53,6 +53,12 @@ try {
   }
 
   console.log(`📦 Binary found: ${binaryPath}`);
+
+  // Unix系OS（Linux, macOS）では実行権限を付与
+  if (platform === "linux" || platform === "darwin") {
+    chmodSync(binaryPath, 0o755);
+    console.log("   ✅ Set execute permission for binary");
+  }
 
   // Test 1: Version
   console.log("\n1️⃣ Testing --version:");


### PR DESCRIPTION
## Summary

This PR updates README badges and improves binary testing infrastructure.

## Changes

### 📝 Documentation Updates
- **Fixed CI badge links**: Updated to correct workflow name (`ci-push-main.yml`)
- **Added new badges**:
  - npm Release badge
  - Homebrew Release badge
  - Node.js version badge
  - npm bundle size badge
  - TypeScript types badge
- **Improved table formatting**: Better formatting for options table in Japanese README

### 🔧 Build & Test Improvements
- **Auto-set binary execute permissions**: Automatically sets execute permissions (755) for binaries on Linux/macOS during tests
  - Issue: Binary tests were failing on Linux due to missing execute permissions
  - Solution: Added platform detection in `test-binary.js` to run `chmod 755` on Unix-like systems

### 📄 Other
- Added clarification comment that Linux ARM64 runner is only available for public repositories

## Test Results

All CI tests pass on all supported platforms.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>