### PR TITLE
feat: add GitHub App token support for protected branch pushes

### DIFF
--- a/.github/workflows/cd-homebrew-release.yml
+++ b/.github/workflows/cd-homebrew-release.yml
@@ -20,6 +20,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Validate tag format
         if: github.event_name == 'workflow_dispatch'
         id: validate_tag
@@ -65,7 +72,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
+          HOMEBREW_TAP_PUSH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/cd-npm-release.yml
+++ b/.github/workflows/cd-npm-release.yml
@@ -80,5 +80,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "🍺 Triggering Homebrew release for tag ${{ steps.get_tag.outputs.tag_name }}"
-          gh workflow run cd-homebrew-release.yml \
-            -f tag_name=${{ steps.get_tag.outputs.tag_name }}
+          bun run trigger:workflow:cd-homebrew-release

--- a/.github/workflows/manual-force-version-bump.yml
+++ b/.github/workflows/manual-force-version-bump.yml
@@ -5,14 +5,13 @@ on:
     inputs:
       version_type:
         description: 'Version bump type'
-        required: true
+        required: false
         default: 'patch'
         type: choice
         options:
           - patch
           - minor
           - major
-          - custom
       custom_version:
         description: 'Custom version WITHOUT v prefix (e.g., 1.2.3, NOT v1.2.3)'
         required: false
@@ -29,7 +28,7 @@ permissions:
 jobs:
   create-release-commit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,16 +51,15 @@ jobs:
         id: current_version
         run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
 
-      - name: Check custom version is provided
-        if: github.event.inputs.version_type == 'custom'
+      - name: Validate inputs
         run: |
-          if [ -z "${{ github.event.inputs.custom_version }}" ]; then
-            echo "::error::Custom version is required when version_type is 'custom'"
+          if [ -z "${{ github.event.inputs.custom_version }}" ] && [ -z "${{ github.event.inputs.version_type }}" ]; then
+            echo "::error::Either version_type or custom_version must be provided"
             exit 1
           fi
 
       - name: Validate custom version format
-        if: github.event.inputs.version_type == 'custom'
+        if: github.event.inputs.custom_version != ''
         id: validate_version
         uses: matt-usurp/validate-semver@v2
         with:
@@ -73,7 +71,7 @@ jobs:
           CURRENT="${{ steps.current_version.outputs.version }}"
           echo "Current version: $CURRENT"
           
-          if [ "${{ github.event.inputs.version_type }}" = "custom" ]; then
+          if [ -n "${{ github.event.inputs.custom_version }}" ]; then
             NEXT="${{ steps.validate_version.outputs.version }}"
           else
             # Use npx semver to calculate next version

--- a/.github/workflows/manual-force-version-bump.yml
+++ b/.github/workflows/manual-force-version-bump.yml
@@ -30,10 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
           ref: main
 

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   pr-auto-assign:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -69,7 +69,7 @@ homebrew_casks:
       name: homebrew-tap
       branch: main
       # Use GitHub App token or PAT with repo permissions
-      token: "{{ .Env.HOMEBREW_GITHUB_API_TOKEN }}"
+      token: "{{ .Env.HOMEBREW_TAP_PUSH_TOKEN }}"
       
     # Git author for formula commits
     commit_author:


### PR DESCRIPTION
## Summary
- Add GitHub App token generation to bypass branch protection rules
- Rename HOMEBREW_GITHUB_API_TOKEN to HOMEBREW_TAP_PUSH_TOKEN for clarity
- Add comprehensive Japanese documentation for GitHub App setup

## Changes
1. **manual-force-version-bump.yml**: Add GitHub App token generation for direct pushes to main branch
2. **cd-homebrew-release.yml**: Add GitHub App token generation for GoReleaser
3. **.goreleaser.yaml**: Update environment variable name to HOMEBREW_TAP_PUSH_TOKEN
4. **docs/GITHUB_APP_SETUP.md**: Add Japanese documentation for GitHub App setup process

## Test plan
- [ ] Create GitHub App with required permissions
- [ ] Add APP_ID and APP_PRIVATE_KEY to repository secrets
- [ ] Test manual-force-version-bump workflow
- [ ] Test cd-homebrew-release workflow

🤖 Generated with [Claude Code](https://claude.ai/code)