### PR TITLE
fix: remove reason parameter from manual version bump workflow

### DIFF
--- a/.github/workflows/manual-force-version-bump.yml
+++ b/.github/workflows/manual-force-version-bump.yml
@@ -13,7 +13,7 @@ on:
           - minor
           - major
       custom_version:
-        description: 'Custom version WITHOUT v prefix (e.g., 1.2.3, NOT v1.2.3)'
+        description: 'Custom version WITHOUT v prefix (e.g., 1.2.3, NOT v1.2.3) - If provided, this takes precedence; if empty, version_type will be used'
         required: false
         type: string
 


### PR DESCRIPTION
## Summary
- Remove the `reason` input parameter from the manual version bump workflow
- Update commit message to use `chore: bump version to X.X.X` format instead of using the reason
- Clarify that custom_version takes precedence over version_type in the description

## Changes
1. Removed the `reason` workflow input parameter that was no longer needed
2. Changed the commit message format from `chore: ${reason}` to `chore: bump version to X.X.X` to be more explicit about the action
3. Updated the custom_version description to clarify the precedence behavior: "If provided, this takes precedence; if empty, version_type will be used"

## Test plan
- [ ] Manually trigger the workflow with version_type only
- [ ] Manually trigger the workflow with custom_version only
- [ ] Verify the commit message shows the correct format
- [ ] Verify Release-Please picks up the version bump correctly

🤖 Generated with [Claude Code](https://claude.ai/code)