### PR TITLE
fix: add permissions to pr-auto-assign workflow and improve branch lint config

### DIFF
--- a/.elsikora/git-branch-lint.config.ts
+++ b/.elsikora/git-branch-lint.config.ts
@@ -1,5 +1,7 @@
 import type { IBranchLintConfig } from "@elsikora/git-branch-lint";
 
+// Configuration for Git Branch Lint
+// See: https://github.com/ElsiKora/Git-Branch-Lint
 const config: IBranchLintConfig = {
   branches: [
     // Standard GitFlow branch types
@@ -32,7 +34,6 @@ const config: IBranchLintConfig = {
   rules: {
     "branch-pattern": ":type/:name",
     "branch-subject-pattern": "[a-z0-9-]+",
-    "branch-prohibited": ["master", "prod", "production"],
     "branch-min-length": 5,
     "branch-max-length": 50,
   },

--- a/.elsikora/git-branch-lint.config.ts
+++ b/.elsikora/git-branch-lint.config.ts
@@ -1,21 +1,27 @@
 import type { IBranchLintConfig } from "@elsikora/git-branch-lint";
 
 const config: IBranchLintConfig = {
-  // Branch prefixes based on Conventional Commits types (not traditional GitFlow)
-  // These prefixes align with commit message types for consistency
   branches: [
-    "feat",
-    "feature",
-    "fix",
-    "docs",
-    "style",
-    "refactor",
-    "test",
-    "chore",
-    "ci",
-    "perf",
-    "build",
-    "revert",
+    // GitFlow branch types (still actively used)
+    "feature", // New features
+    "release", // Prepare for a new production release
+    "hotfix", // Quick fixes to production
+    "bugfix", // Bug fixes for development branch
+    "support", // Support branches for older versions
+
+    // Conventional Commits-based branch types
+    // These align with commit message types for consistency
+    "feat", // New features (Conventional Commits style)
+    "fix", // Bug fixes (Conventional Commits style)
+    "docs", // Documentation only changes
+    "style", // Code style changes (formatting, missing semi-colons, etc)
+    "refactor", // Code refactoring without changing functionality
+    "test", // Adding or correcting tests
+    "chore", // Maintenance tasks, dependency updates, etc
+    "ci", // Changes to CI configuration files and scripts
+    "perf", // Performance improvements
+    "build", // Changes affecting build system or dependencies
+    "revert", // Reverting previous commits
   ],
   ignore: [
     "main",

--- a/.elsikora/git-branch-lint.config.ts
+++ b/.elsikora/git-branch-lint.config.ts
@@ -2,12 +2,10 @@ import type { IBranchLintConfig } from "@elsikora/git-branch-lint";
 
 const config: IBranchLintConfig = {
   branches: [
-    // GitFlow branch types (still actively used)
-    "feature", // New features
+    // Standard GitFlow branch types
+    "feature", // New features (branched from develop)
     "release", // Prepare for a new production release
-    "hotfix", // Quick fixes to production
-    "bugfix", // Bug fixes for development branch
-    "support", // Support branches for older versions
+    "hotfix", // Emergency fixes to production (branched from main)
 
     // Conventional Commits-based branch types
     // These align with commit message types for consistency
@@ -24,7 +22,10 @@ const config: IBranchLintConfig = {
     "revert", // Reverting previous commits
   ],
   ignore: [
+    // GitFlow main branches (long-lived)
     "main",
+    "develop", // GitFlow development branch
+
     // Release Please creates this branch automatically for release management
     "release-please--branches--main--components--ai-chat-md-export",
   ],

--- a/.elsikora/git-branch-lint.config.ts
+++ b/.elsikora/git-branch-lint.config.ts
@@ -1,6 +1,8 @@
 import type { IBranchLintConfig } from "@elsikora/git-branch-lint";
 
 const config: IBranchLintConfig = {
+  // Branch prefixes based on Conventional Commits types (not traditional GitFlow)
+  // These prefixes align with commit message types for consistency
   branches: [
     "feat",
     "feature",
@@ -17,6 +19,7 @@ const config: IBranchLintConfig = {
   ],
   ignore: [
     "main",
+    // Release Please creates this branch automatically for release management
     "release-please--branches--main--components--ai-chat-md-export",
   ],
   rules: {

--- a/.github/pr-auto-assign-config.yml
+++ b/.github/pr-auto-assign-config.yml
@@ -5,7 +5,8 @@
 addReviewers: true
 
 # Set to true to add assignees to pull requests
-addAssignees: false
+# Set addAssignees to 'author' to set the PR creator as the assignee.
+addAssignees: author
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     types: [opened, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   pr-auto-assign:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix "Resource not accessible by integration" error in PR auto-assign workflow
- Enable automatic PR creator assignment
- Improve git-branch-lint configuration with better documentation

## Changes
1. **PR Auto-assign Workflow**
   - Add explicit permissions (`contents: read`, `pull-requests: write`, `issues: write`)
   - Change `addAssignees` from `false` to `author` to automatically assign PR creator

2. **Git Branch Lint Configuration**
   - Add documentation link to ElsiKora/Git-Branch-Lint
   - Organize branch types into GitFlow and Conventional Commits groups
   - Remove non-standard GitFlow branches (bugfix, support)
   - Add `develop` to ignore list as a long-lived GitFlow branch
   - Remove unnecessary `branch-prohibited` rule

## Test plan
- [ ] Create a new PR and verify that auto-assign works correctly
- [ ] Verify that the reviewer is automatically added
- [ ] Check that the PR creator is automatically assigned
- [ ] Confirm branch naming validation works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)