### PR TITLE
fix: add id-token permission to npm release workflow

### DIFF
--- a/.github/workflows/cd-npm-release.yml
+++ b/.github/workflows/cd-npm-release.yml
@@ -14,6 +14,7 @@ permissions:
   pull-requests: write
   issues: write
   packages: write
+  # Required for the cd-homebrew-release workflow that uses GitHub App authentication
   id-token: write
 
 jobs:

--- a/.github/workflows/cd-npm-release.yml
+++ b/.github/workflows/cd-npm-release.yml
@@ -14,6 +14,7 @@ permissions:
   pull-requests: write
   issues: write
   packages: write
+  id-token: write
 
 jobs:
   cd-npm-release:

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,12 @@ dist/
 lib/
 
 # editor
-.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
 *.swp
 *.swo
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,45 @@
+{
+  "editor.formatOnSave": true,
+  "biome.lsp.bin": "node_modules/.bin/biome",
+  "editor.codeActionsOnSave": {
+    "quickfix.biome": "explicit",
+    "source.organizeImports.biome": "explicit"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json5]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "tailwindCSS.classFunctions": ["cva", "cx", "cn", "twMerge"],
+  "tailwindCSS.experimental.classRegex": [
+    ["([\"'`][^\"'`]*.*?[\"'`])", "[\"'`]([^\"'`]*).*?[\"'`]"]
+  ],
+  "files.associations": {
+    "*.css": "tailwindcss",
+    "bun.lock": "json5"
+  },
+  "npm.packageManager": "bun",
+  "npm.scriptRunner": "bun",
+  "debug.javascript.defaultRuntimeExecutable": {
+    "pwa-node": "bun"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission to the npm release workflow to enable npm provenance publishing

## Test plan
- [ ] Check that the workflow can successfully publish to npm with provenance attestations
- [ ] Verify no permission errors occur during the npm publish step

🤖 Generated with [Claude Code](https://claude.ai/code)