### PR TITLE
fix: add multi-repository permissions for GitHub App token

### DIFF
--- a/.github/workflows/cd-homebrew-release.yml
+++ b/.github/workflows/cd-homebrew-release.yml
@@ -33,6 +33,10 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            ai-chat-md-export
+            homebrew-tap
 
       - name: Validate tag has v prefix
         run: |

--- a/scripts/test-npm-package.js
+++ b/scripts/test-npm-package.js
@@ -21,14 +21,26 @@ const packageName = "ai-chat-md-export";
 let packageFile = null;
 let isInstalled = false;
 
-// Clean up any existing installation first
+// Clean up any existing Homebrew installation first
 try {
-  console.log("🧹 Checking for existing installation...");
+  console.log("🧹 Checking for existing Homebrew installation...");
+  execSync(`brew list ${packageName}`, { stdio: "pipe" });
+  console.log("📦 Found Homebrew installation, uninstalling...");
+  execSync(`brew uninstall ${packageName}`, { stdio: "pipe" });
+  console.log("✅ Removed Homebrew installation");
+} catch (_e) {
+  // Package not installed via Homebrew, which is fine
+  console.log("✅ No Homebrew installation found");
+}
+
+// Clean up any existing npm installation
+try {
+  console.log("🧹 Checking for existing npm installation...");
   execSync(`npm uninstall -g ${packageName}`, { stdio: "pipe" });
-  console.log("✅ Removed existing installation");
+  console.log("✅ Removed existing npm installation");
 } catch (_e) {
   // Package not installed, which is fine
-  console.log("✅ No existing installation found");
+  console.log("✅ No existing npm installation found");
 }
 
 try {
@@ -92,10 +104,20 @@ try {
   if (isInstalled) {
     try {
       execSync(`npm uninstall -g ${packageName}`, { stdio: "pipe" });
-      console.log("✅ Package uninstalled");
+      console.log("✅ npm package uninstalled");
     } catch (_e) {
-      console.warn("⚠️  Failed to uninstall package");
+      console.warn("⚠️  Failed to uninstall npm package");
     }
+  }
+
+  // Also check and clean up any Homebrew installation that might have been created
+  try {
+    execSync(`brew list ${packageName}`, { stdio: "pipe" });
+    console.log("📦 Found Homebrew installation during cleanup, removing...");
+    execSync(`brew uninstall ${packageName}`, { stdio: "pipe" });
+    console.log("✅ Homebrew package uninstalled");
+  } catch (_e) {
+    // Not installed via Homebrew, which is expected
   }
 
   if (packageFile && existsSync(join(projectRoot, packageFile))) {


### PR DESCRIPTION
## Summary
- Fix 403 error when GoReleaser tries to push to homebrew-tap repository
- Add owner and repositories parameters to GitHub App token generation
- Improve npm package test to handle Homebrew installations

## Problem
The GoReleaser workflow was failing with:
```
homebrew cask: could not update "Casks/ai-chat-md-export.rb": PUT https://api.github.com/repos/sugurutakahashi-1234/homebrew-tap/contents/Casks/ai-chat-md-export.rb: 403 Resource not accessible by integration []
```

## Solution
Update the GitHub App token generation to explicitly include both repositories:
- `ai-chat-md-export` (current repository)
- `homebrew-tap` (target repository for Homebrew formula)

## Additional Changes
Also improved the npm package test script to:
- Check and uninstall any existing Homebrew installation before npm tests
- Add Homebrew cleanup in the finally block
- Ensure no conflicts between npm and Homebrew installations

## Test plan
- [x] Verify the workflow file syntax is correct
- [x] Test npm package script runs successfully with Homebrew handling
- [ ] Confirm GitHub App has necessary permissions for both repositories
- [ ] Test the cd-homebrew-release workflow with a new release

🤖 Generated with [Claude Code](https://claude.ai/code)