### PR TITLE
fix: add missing closing bracket in Homebrew Cask post-install hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -104,7 +104,7 @@ homebrew_casks:
       post:
         install: |
           if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
-            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ai-chat-md-export"
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ai-chat-md-export"]
           end
 
 # Announce release in various channels


### PR DESCRIPTION
## Summary
- Fix Ruby syntax error in GoReleaser configuration that was breaking Homebrew installations
- Add missing closing bracket `]` to the system_command args array

## Problem
When trying to install via Homebrew, users were getting this error:
```
Error: Cask 'ai-chat-md-export' is unreadable: /opt/homebrew/Library/Taps/sugurutakahashi-1234/homebrew-tap/Casks/ai-chat-md-export.rb:42: syntax errors found
  40 |     if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
  41 |       system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ai-chat-md-export"
> 42 |     end
     | ^ expected an expression for the array element
```

## Root Cause
The `.goreleaser.yaml` was missing a closing bracket `]` in the system_command args array on line 107.

## Solution
Added the missing closing bracket to fix the Ruby syntax:
```yaml
# Before
system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ai-chat-md-export"

# After  
system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/ai-chat-md-export"]
```

## Test plan
- [ ] Merge this PR
- [ ] Create a new release to trigger GoReleaser
- [ ] Verify the generated Homebrew Cask has valid Ruby syntax
- [ ] Test installation: `brew install sugurutakahashi-1234/tap/ai-chat-md-export`

🤖 Generated with [Claude Code](https://claude.ai/code)