### PR TITLE
fix: debug and workaround for Windows artifact upload permission issue

### DIFF
--- a/.github/workflows/cd-homebrew-release.yml
+++ b/.github/workflows/cd-homebrew-release.yml
@@ -98,6 +98,18 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           HOMEBREW_TAP_PUSH_TOKEN: ${{ steps.generate-token.outputs.token }}
 
+      - name: Pre-compress Windows executables for artifact upload
+        if: failure()
+        run: |
+          echo "🗜️ Pre-compressing Windows executables to avoid permission issues..."
+          find dist -name "*.exe" -type f | while read exe; do
+            echo "Compressing: $exe"
+            tar -czf "${exe}.tar.gz" -C "$(dirname "$exe")" "$(basename "$exe")"
+            echo "Created: ${exe}.tar.gz"
+            rm -f "$exe"
+            echo "Removed original: $exe"
+          done
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -109,6 +109,36 @@ jobs:
           echo "📦 Built binaries:"
           find dist -name "ai-chat-md-export*" -type f ! -name "*.tar.gz" ! -name "*.zip" -exec ls -lh {} \;
 
+      - name: Debug - Check file permissions and ownership
+        run: |
+          echo "🔍 Detailed file permissions and ownership:"
+          find dist -type f -exec ls -la {} \; | sort
+          echo ""
+          echo "🔍 File attributes (using stat):"
+          find dist -name "*.exe" -type f -exec stat {} \;
+          echo ""
+          echo "🔍 Current user and groups:"
+          whoami
+          id
+          echo ""
+          echo "🔍 Directory permissions:"
+          ls -la dist/
+          find dist -type d -exec ls -ld {} \;
+
+      - name: Pre-compress Windows executables
+        run: |
+          echo "🗜️ Pre-compressing Windows executables to avoid permission issues..."
+          find dist -name "*.exe" -type f | while read exe; do
+            echo "Compressing: $exe"
+            tar -czf "${exe}.tar.gz" -C "$(dirname "$exe")" "$(basename "$exe")"
+            echo "Created: ${exe}.tar.gz"
+            rm -f "$exe"
+            echo "Removed original: $exe"
+          done
+          echo ""
+          echo "📦 Files after compression:"
+          find dist -type f -name "*.tar.gz" -o -name "*.exe" | sort
+
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         if: always()


### PR DESCRIPTION
## Summary
- Add debug information to identify Windows executable permission issues
- Pre-compress Windows executables (.exe) before upload-artifact to avoid EACCES errors
- Apply workaround to both CI and release workflows

## Problem
Windows executable files cause "EACCES: permission denied" errors during artifact upload in GitHub Actions. This occurs when upload-artifact@v4 tries to create zip files containing Windows .exe files.

## Solution
1. **Debug steps added**: Detailed file permissions and ownership information
2. **Workaround implemented**: Pre-compress Windows executables into tar.gz files before upload
3. **Original .exe files removed**: After compression to prevent the permission error

## Debug output will show:
- Detailed file permissions and ownership
- File attributes using stat command
- Current user and groups
- Directory permissions

## Test plan
- [x] Local CI passes
- [ ] GitHub Actions workflow shows debug information
- [ ] Windows executables are successfully uploaded as .tar.gz files
- [ ] No more EACCES errors during artifact upload

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>