### PR TITLE
fix: set proper permissions for all binaries in GoReleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -21,6 +21,12 @@ builds:
       - linux-x64-modern    # Linux x64 (modern CPUs with AVX2)
       - linux-arm64         # Linux ARM64 (Raspberry Pi, AWS Graviton, etc.)
       - windows-x64-modern  # Windows x64 (modern CPUs with AVX2)
+    hooks:
+      post:
+        # Set proper permissions for all binaries
+        # Bun builder creates Windows .exe with 0000 and Unix binaries with 0777
+        # Set all to 0755 (standard executable permissions)
+        - sh -c 'find dist -name "{{ .ProjectName }}*" -type f -exec chmod 755 {} \;'
 
 # Archive configuration
 # https://goreleaser.com/customization/archive/


### PR DESCRIPTION
## Summary
- Add post hooks in GoReleaser to fix binary permissions
- Fixes Windows .exe files created with 0000 permissions
- Normalizes Unix binaries from 0777 to standard 0755 permissions

## Problem
The debug logs from GitHub Actions revealed that Bun builder creates:
- Windows executables with 0000 permissions (no access at all)
- Unix binaries with 0777 permissions (too permissive)

This causes:
1. `tar` command fails with "Permission denied" when trying to compress Windows .exe
2. `upload-artifact` fails with EACCES error when trying to read Windows .exe

## Solution
Added a post hook in `.goreleaser.yaml` that sets all binaries to 0755 permissions:
- Readable and executable by everyone
- Standard permissions for distributed binaries
- Works for both Windows and Unix executables

## Test Results
Local test confirms all binaries now have proper permissions:
```
-rwxr-xr-x  ai-chat-md-export (Unix binaries)
-rwxr-xr-x  ai-chat-md-export.exe (Windows binary)
```

## Test plan
- [x] Local build test passes with correct permissions
- [x] CI passes locally
- [ ] GitHub Actions workflow succeeds after merge
- [ ] Artifact upload works without permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>