### PR TITLE
fix: ubuntu binary permission error in CI

### DIFF
--- a/.github/workflows/ci-push-main.yml
+++ b/.github/workflows/ci-push-main.yml
@@ -145,5 +145,14 @@ jobs:
           name: goreleaser-test-artifacts
           path: dist
 
+      # Set execute permissions for binaries on Unix-like systems
+      # This is necessary because GitHub Actions' upload-artifact/download-artifact
+      # does NOT preserve file permissions. Even though GoReleaser already sets
+      # proper permissions (755) during build, they are lost during artifact transfer.
+      # Windows doesn't need this step as .exe files are automatically executable.
+      - name: Set binary permissions
+        run: chmod +x dist/*/ai-chat-md-export*
+        if: runner.os != 'Windows'
+
       - name: Test binary
         run: bun scripts/test-binary.js


### PR DESCRIPTION
## Summary
- Added chmod step to restore execute permissions for binaries after artifact download
- Fixes "Permission denied" errors on Linux/macOS test runners

## Problem
GitHub Actions' `upload-artifact@v4` and `download-artifact@v4` do not preserve file permissions. Even though GoReleaser correctly sets 755 permissions during build, these permissions are lost when artifacts are transferred between jobs.

## Solution
Added a `Set binary permissions` step that:
- Runs `chmod +x` on all downloaded binaries
- Only executes on Unix-like systems (Linux/macOS)
- Skips Windows since .exe files are automatically executable

## Test Results
- ✅ Windows tests continue to work (no chmod needed)
- ✅ Linux/macOS tests should now pass with proper permissions

🤖 Generated with [Claude Code](https://claude.ai/code)