### PR TITLE
docs: clarify that ai-chat-md-export is a CLI tool

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/sugurutakahashi-1234/ai-chat-md-export)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/pulls)
 
-ChatGPTとClaudeのチャット履歴を読みやすいMarkdownファイルに変換
+ChatGPTとClaudeのチャット履歴を読みやすいMarkdownファイルに変換するコマンドラインツール
 
 ![Demo](docs/assets/demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/sugurutakahashi-1234/ai-chat-md-export)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/pulls)
 
-Convert ChatGPT and Claude chat history to readable Markdown files
+Command-line tool for converting ChatGPT and Claude chat history to readable Markdown files
 
 ![Demo](docs/assets/demo.gif)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 [![GitHub Release Date](https://img.shields.io/github/release-date/sugurutakahashi-1234/ai-chat-md-export)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/releases)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/sugurutakahashi-1234/ai-chat-md-export/pulls)
 
-将 ChatGPT 和 Claude 聊天记录转换为可读的 Markdown 文件
+用于将 ChatGPT 和 Claude 聊天记录转换为可读 Markdown 文件的命令行工具
 
 ![Demo](docs/assets/demo.gif)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-chat-md-export",
   "version": "1.0.1",
-  "description": "Convert ChatGPT and Claude chat history to readable Markdown files",
+  "description": "Command-line tool for converting ChatGPT and Claude chat history to readable Markdown files",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
- Clarify in documentation that this is a command-line tool, not just a general converter
- Update descriptions in README files and package.json to explicitly mention "CLI" or "command-line tool"

## Changes
- Updated English README.md description
- Updated Japanese README.ja.md description  
- Updated Chinese README.zh-CN.md description
- Updated package.json description field

## Why this matters
Users visiting the repository should immediately understand that this is a CLI tool they run from the terminal, not a library or web service.

🤖 Generated with [Claude Code](https://claude.ai/code)